### PR TITLE
Auto corrected by following Lint Ruby EmptyLine

### DIFF
--- a/lib/rspec/json_matchers/expectation.rb
+++ b/lib/rspec/json_matchers/expectation.rb
@@ -118,6 +118,7 @@ module RSpec
           if object < Expectations::Core::SingletonExpectation
             return object::INSTANCE
           end
+
           Expectations::Private::KindOf[object]
         end
 

--- a/lib/rspec/json_matchers/expectations/private.rb
+++ b/lib/rspec/json_matchers/expectations/private.rb
@@ -63,6 +63,7 @@ module RSpec
             unless value.is_a?(EXPECTED_CLASS)
               fail ArgumentError, "a #{EXPECTED_CLASS} is required"
             end
+
             @expected_class = value
           end
         end
@@ -88,6 +89,7 @@ module RSpec
             unless value.is_a?(EXPECTED_CLASS)
               fail ArgumentError, "a #{EXPECTED_CLASS} is required"
             end
+
             @range = value
           end
         end
@@ -115,6 +117,7 @@ module RSpec
             unless value.is_a?(EXPECTED_CLASS)
               fail ArgumentError, "a #{EXPECTED_CLASS} is required"
             end
+
             @regexp = value
           end
         end

--- a/lib/rspec/json_matchers/matchers/be_json_with_content_matcher.rb
+++ b/lib/rspec/json_matchers/matchers/be_json_with_content_matcher.rb
@@ -70,12 +70,14 @@ module RSpec
         # Overrides {BeJsonMatcher#failure_message}
         def failure_message
           return super if has_parser_error?
+
           failure_message_for(true)
         end
 
         # Overrides {BeJsonMatcher#failure_message_when_negated}
         def failure_message_when_negated
           return super if has_parser_error?
+
           failure_message_for(false)
         end
 

--- a/lib/rspec/json_matchers/utils/key_path/path.rb
+++ b/lib/rspec/json_matchers/utils/key_path/path.rb
@@ -79,6 +79,7 @@ module RSpec
           def extract(object)
             return Extraction::Result.new(object, true) if empty?
             return Extraction::Result.new(object, false) if invalid?
+
             Extraction.new(object, self).extract
           end
 


### PR DESCRIPTION
Auto corrected by following Lint Ruby EmptyLine

Click [here](https://awesomecode.io/repos/PikachuEXE/rspec-json_matchers/ruby_config_groups/696) to configure it on awesomecode.io