### PR TITLE
Auto corrected by following Lint Ruby Style/ExpandPathArguments

### DIFF
--- a/rspec-json_matchers.gemspec
+++ b/rspec-json_matchers.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "rspec/json_matchers/version"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 require "rspec-json_matchers"
 
 if ENV["TRAVIS"]


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/ExpandPathArguments

Click [here](https://awesomecode.io/repos/PikachuEXE/rspec-json_matchers/lint_configs/ruby/16517) to configure it on awesomecode.io